### PR TITLE
pool.sks-keyservers.net is down

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN \
    CHECKSUM=$(sha256sum nsd-${NSD_VERSION}.tar.gz | awk '{print $1}') && \
    if [ "${CHECKSUM}" != "${SHA256_HASH}" ]; then echo "ERROR: Checksum does not match!" && exit 1; fi && \
    ( \
-      gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${GPG_FINGERPRINT} || \
+      gpg --keyserver keyserver.ubuntu.com --recv-keys ${GPG_FINGERPRINT} || \
       gpg --keyserver keyserver.pgp.com --recv-keys ${GPG_FINGERPRINT} || \
       gpg --keyserver pgp.mit.edu --recv-keys ${GPG_FINGERPRINT} \
    ) && \


### PR DESCRIPTION
In my environment, `Docker Build` doesn't succeed because `pool.sks-keyservers.net` is down. So I rewrote it to `keyserver.ubuntu.com` and it worked. 
```
# sudo docker build ./ -t nsd --no-cache
[+] Building 227.5s (9/16)
 => [internal] load build definition from Dockerfile                                                                                                                                0.0s
 => => transferring dockerfile: 2.40kB                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                    0.8s
 => [internal] load build context                                                                                                                                                   0.1s
 => => transferring context: 3.63kB                                                                                                                                                 0.0s
 => CACHED [builder 1/8] FROM docker.io/library/alpine:latest@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300                                               0.0s
 => [stage-1 2/5] RUN apk add --no-cache    ldns    ldns-tools    libevent    openssl    tini                                                                                       2.6s
 => [builder 2/8] RUN apk add --no-cache       bash       curl       gnupg       build-base       libevent-dev       openssl-dev       ca-certificates                             10.5s
 => [builder 3/8] WORKDIR /tmp                                                                                                                                                      0.1s
 => ERROR [builder 4/8] RUN    curl -OO https://www.nlnetlabs.nl/downloads/nsd/nsd-4.3.9.tar.gz{,.asc} &&    echo "Verifying authenticity of nsd-4.3.9.tar.gz..." &&    CHECKSUM  215.9s
------
 > [builder 4/8] RUN    curl -OO https://www.nlnetlabs.nl/downloads/nsd/nsd-4.3.9.tar.gz{,.asc} &&    echo "Verifying authenticity of nsd-4.3.9.tar.gz..." &&    CHECKSUM=$(sha256sum nsd-4.3.9.tar.gz | awk '{print $1}') &&    if [ "${CHECKSUM}" != "531549f09289ecbd05829e14bb34563294d85b9edde2c613a00f597af2135e8d" ]; then echo "ERROR: Checksum does not match!" && exit 1; fi &&    (       gpg --keyserver ha.pool.sks-keyservers.net --recv-keys EDFAA3F2CA4E6EB05681AF8E9F6F1C2D7E045F8D ||       gpg --keyserver keyserver.pgp.com --recv-keys EDFAA3F2CA4E6EB05681AF8E9F6F1C2D7E045F8D ||       gpg --keyserver pgp.mit.edu --recv-keys EDFAA3F2CA4E6EB05681AF8E9F6F1C2D7E045F8D    ) &&    FINGERPRINT="$(LANG=C gpg --verify nsd-4.3.9.tar.gz.asc nsd-4.3.9.tar.gz 2>&1                 | sed -n 's#^Primary key fingerprint: \(.*\)#\1#p' | tr -d '[:space:]')" &&    if [ -z "${FINGERPRINT}" ]; then echo "ERROR: Invalid GPG signature!" && exit 1; fi &&    if [ "${FINGERPRINT}" != "EDFAA3F2CA4E6EB05681AF8E9F6F1C2D7E045F8D" ]; then echo "ERROR: Wrong GPG fingerprint!" && exit 1; fi &&    echo "SHA256 and GPG signature are correct":
#8 0.394   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#8 0.396                                  Dload  Upload   Total   Spent    Left  Speed
100 1194k  100 1194k    0     0   134k      0  0:00:08  0:00:08 --:--:--  178k
#8 9.288   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#8 9.288                                  Dload  Upload   Total   Spent    Left  Speed
100   833  100   833    0     0   3440      0 --:--:-- --:--:-- --:--:--  3456
#8 9.535 Verifying authenticity of nsd-4.3.9.tar.gz...
#8 9.551 gpg: directory '/root/.gnupg' created
#8 9.553 gpg: keybox '/root/.gnupg/pubring.kbx' created
#8 19.65 gpg: keyserver receive failed: Server indicated a failure
#8 81.86 gpg: keyserver receive failed: Operation timed out
#8 215.8 gpg: keyserver receive failed: No keyserver available
------
executor failed running [/bin/bash -o pipefail -c curl -OO https://www.nlnetlabs.nl/downloads/nsd/nsd-${NSD_VERSION}.tar.gz{,.asc} &&    echo "Verifying authenticity of nsd-${NSD_VERSION}.tar.gz..." &&    CHECKSUM=$(sha256sum nsd-${NSD_VERSION}.tar.gz | awk '{print $1}') &&    if [ "${CHECKSUM}" != "${SHA256_HASH}" ]; then echo "ERROR: Checksum does not match!" && exit 1; fi &&    (       gpg --keyserver ha.pool.sks-keyservers.net --recv-keys ${GPG_FINGERPRINT} ||       gpg --keyserver keyserver.pgp.com --recv-keys ${GPG_FINGERPRINT} ||       gpg --keyserver pgp.mit.edu --recv-keys ${GPG_FINGERPRINT}    ) &&    FINGERPRINT="$(LANG=C gpg --verify nsd-${NSD_VERSION}.tar.gz.asc nsd-${NSD_VERSION}.tar.gz 2>&1                 | sed -n 's#^Primary key fingerprint: \(.*\)#\1#p' | tr -d '[:space:]')" &&    if [ -z "${FINGERPRINT}" ]; then echo "ERROR: Invalid GPG signature!" && exit 1; fi &&    if [ "${FINGERPRINT}" != "${GPG_FINGERPRINT}" ]; then echo "ERROR: Wrong GPG fingerprint!" && exit 1; fi &&    echo "SHA256 and GPG signature are correct"]: exit code: 2
```
This service is already deprecated 
>This service is deprecated. This means it is no longer maintained, and new HKPS certificates will not be issued. Service reliability should not be expected.

from https://sks-keyservers.net/