### PR TITLE
update cronjob apiversion

### DIFF
--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -203,7 +203,7 @@ roleRef:
   apiGroup: ""
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: nsd-rollout


### PR DESCRIPTION
cronjob is in feature-state since kubernetes 1.21, beta-state will be deprecated in 1.25

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125